### PR TITLE
json stringify should be optional

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,13 @@
-const csvDownload = (data, name, delimiter) => {
+const csvDownload = (data, name, delimiter, stringify) => {
   const items = data
   const filename = name || `export.csv`
   const d = delimiter || `,`
+  const json_stringify = stringify
 
   const header = Array.from(
     new Set(items.reduce((r, e) => [...r, ...Object.keys(e)], []))
   )
-  let csv = items.map(row =>
-    header.map(fieldName => JSON.stringify(row[fieldName] || '')).join(d)
-  )
+  let csv = items.map(row => header.map(fieldName => json_stringify ? JSON.stringify(row[fieldName] || '') : (row[fieldName] || '')).join(d))
   csv.unshift(header.join(d))
   csv = csv.join('\r\n')
 


### PR DESCRIPTION
I have some issues when the string contains double quotes, example for for inch marks.